### PR TITLE
feat: surface closelix flag and hide target

### DIFF
--- a/src/components/clients/ClientEditDialog.tsx
+++ b/src/components/clients/ClientEditDialog.tsx
@@ -86,10 +86,10 @@ export function ClientEditDialog({
         client_website: client.client_website || '',
         relationship_status: client.relationship_status || '',
         relationship_type: client.relationship_type || '',
+        closelix: client.closelix === true ? 'true' : client.closelix === false ? 'false' : '',
         weekend_sending_mode: client.weekend_sending_mode || 'inherit',
         assigned_account_manager_id: client.assigned_account_manager_id || '',
         assigned_inbox_manager_id: client.assigned_inbox_manager_id || '',
-        avg_dollar_gen_pm: client.avg_dollar_gen_pm ?? '',
         phone_number: client.phone_number || '',
         booking_link: client.booking_link || '',
         recurring_cost_usd: client.recurring_cost_usd ?? '',
@@ -102,8 +102,8 @@ export function ClientEditDialog({
     setSaving(true);
     try {
       // Normalize values: empty strings -> null, numbers -> number, booleans -> boolean, UUID empties -> null
-      const numericFields = new Set(['recurring_cost_usd', 'avg_dollar_gen_pm']);
-      const booleanFields = new Set(['onboarding_activated']);
+      const numericFields = new Set(['recurring_cost_usd']);
+      const booleanFields = new Set(['onboarding_activated', 'closelix']);
       const uuidFields = new Set(['assigned_account_manager_id', 'assigned_inbox_manager_id']);
 
       const normalizeValue = (key: string, value: any) => {
@@ -190,7 +190,6 @@ Client Code: ${client.client_code}
 Client ID: ${client.client_id}
 Company: ${formData.client_company_name ?? "-"}
 Relationship: ${formData.relationship_status ?? "-"} (${formData.relationship_type ?? "-"})
-Target (avg_dollar_gen_pm): ${formData.avg_dollar_gen_pm ?? "-"}
 Weekend Sending: ${formData.weekend_sending_mode ?? "-"}
 
 Regards,
@@ -329,14 +328,32 @@ Operations`
                   ))}
                 </SelectContent>
               </Select>
-            </div>
           </div>
+        </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="weekend_sending_mode">Weekend Sending</Label>
-              <Select
-                value={formData.weekend_sending_mode}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="closelix">Closelix</Label>
+            <Select
+              value={formData.closelix}
+              onValueChange={(value) => setFormData({ ...formData, closelix: value })}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="true">True</SelectItem>
+                <SelectItem value="false">False</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="weekend_sending_mode">Weekend Sending</Label>
+            <Select
+              value={formData.weekend_sending_mode}
                 onValueChange={(value) => setFormData({ ...formData, weekend_sending_mode: value })}
               >
                 <SelectTrigger>
@@ -402,28 +419,18 @@ Operations`
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="avg_dollar_gen_pm">Average $/Month Target</Label>
-              <Input
-                id="avg_dollar_gen_pm"
-                type="number"
-                value={formData.avg_dollar_gen_pm}
-                onChange={(e) => setFormData({ ...formData, avg_dollar_gen_pm: parseFloat(e.target.value) || 0 })}
-                placeholder="5000"
-              />
-            </div>
-            <div>
-              <Label htmlFor="recurring_cost_usd">Recurring Cost (USD)</Label>
-              <Input
-                id="recurring_cost_usd"
-                type="number"
-                value={formData.recurring_cost_usd}
-                onChange={(e) => setFormData({ ...formData, recurring_cost_usd: parseFloat(e.target.value) || 0 })}
-                placeholder="2500"
-              />
-            </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="recurring_cost_usd">Recurring Cost (USD)</Label>
+            <Input
+              id="recurring_cost_usd"
+              type="number"
+              value={formData.recurring_cost_usd}
+              onChange={(e) => setFormData({ ...formData, recurring_cost_usd: parseFloat(e.target.value) || 0 })}
+              placeholder="2500"
+            />
           </div>
+        </div>
         </div>
 
         <DialogFooter className="flex justify-between">

--- a/src/components/clients/ClientsFilters.tsx
+++ b/src/components/clients/ClientsFilters.tsx
@@ -118,6 +118,24 @@ export function ClientsFilters({
           </Select>
         </div>
 
+        {/* Closelix */}
+        <div className="space-y-2">
+          <Label>Closelix</Label>
+          <Select
+            value={filters.closelix || ''}
+            onValueChange={(value) => updateFilter('closelix', value === 'all' ? undefined : value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="true">True</SelectItem>
+              <SelectItem value="false">False</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
         {/* Weekend Sending */}
         <div className="space-y-2">
           <Label>Weekend Sending</Label>

--- a/src/components/clients/ClientsTable.tsx
+++ b/src/components/clients/ClientsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // Note: No routing from row actions; edit opens overlay via onRowClick
-import { ChevronUp, ChevronDown, ExternalLink, Mail, Globe } from 'lucide-react';
+import { ChevronUp, ChevronDown, ExternalLink, Mail, Globe, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -182,6 +182,9 @@ export function ClientsTable({
                 <TableHead>
                   <SortableHeader column="relationship_type">Type</SortableHeader>
                 </TableHead>
+                <TableHead className="text-center">
+                  <SortableHeader column="closelix">Closelix</SortableHeader>
+                </TableHead>
                 <TableHead>
                   <SortableHeader column="weekend_sending_mode">Weekend</SortableHeader>
                 </TableHead>
@@ -190,9 +193,6 @@ export function ClientsTable({
                 </TableHead>
                 <TableHead>
                   <SortableHeader column="assigned_inbox_manager_name">IM</SortableHeader>
-                </TableHead>
-                <TableHead className="text-right">
-                  <SortableHeader column="avg_dollar_gen_pm">Target/Month</SortableHeader>
                 </TableHead>
                 <TableHead>
                   <SortableHeader column="updated_at">Last Updated</SortableHeader>
@@ -249,6 +249,9 @@ export function ClientsTable({
                       </Badge>
                     ) : null}
                   </TableCell>
+                  <TableCell className="text-center">
+                    {client.closelix ? <Check className="h-4 w-4 mx-auto" /> : null}
+                  </TableCell>
                   <TableCell>
                     {getWeekendSendingBadge(client.weekend_sending_mode)}
                   </TableCell>
@@ -297,15 +300,6 @@ export function ClientsTable({
                       }
                       return <span className="text-muted-foreground text-sm">Unassigned</span>;
                     })()}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {client.avg_dollar_gen_pm ? (
-                      <span className="font-mono text-sm">
-                        ${client.avg_dollar_gen_pm.toLocaleString()}
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">—</span>
-                    )}
                   </TableCell>
                   <TableCell>
                     <div className="text-sm text-muted-foreground">

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -34,6 +34,7 @@ export type Database = {
           recurring_cost_usd: number | null
           relationship_status: string | null
           relationship_type: string | null
+          closelix: boolean | null
           updated_at: string
           website_canonical: string | null
           weekend_sending_effective: boolean | null
@@ -58,6 +59,7 @@ export type Database = {
           recurring_cost_usd?: number | null
           relationship_status?: string | null
           relationship_type?: string | null
+          closelix?: boolean | null
           updated_at?: string
           website_canonical?: string | null
           weekend_sending_effective?: boolean | null
@@ -82,6 +84,7 @@ export type Database = {
           recurring_cost_usd?: number | null
           relationship_status?: string | null
           relationship_type?: string | null
+          closelix?: boolean | null
           updated_at?: string
           website_canonical?: string | null
           weekend_sending_effective?: boolean | null

--- a/src/lib/clientsData.ts
+++ b/src/lib/clientsData.ts
@@ -17,7 +17,11 @@ function applyFilters(query: any, filters?: ClientFilters) {
   if (filters.relationship_type) {
     query = query.eq('relationship_type', filters.relationship_type);
   }
-  
+
+  if (filters.closelix) {
+    query = query.eq('closelix', filters.closelix === 'true');
+  }
+
   if (filters.weekend_sending_mode) {
     query = query.eq('weekend_sending_mode', filters.weekend_sending_mode);
   }

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -48,7 +48,11 @@ export const clientsApi = {
     if (filters.relationship_type) {
       query = query.eq('relationship_type', filters.relationship_type);
     }
-    
+
+    if (filters.closelix) {
+      query = query.eq('closelix', filters.closelix === 'true');
+    }
+
     if (filters.weekend_sending_mode) {
       query = query.eq('weekend_sending_mode', filters.weekend_sending_mode);
     }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -7,6 +7,7 @@ export interface Client {
   client_website?: string;
   relationship_status?: string;
   relationship_type?: string;
+  closelix?: boolean;
   onboarding_activated?: boolean;
   onboarding_date?: string;
   recurring_cost_usd?: number;
@@ -61,6 +62,7 @@ export interface ClientStagingRow {
   booking_link?: string;
   phone_number?: string;
   avg_dollar_gen_pm?: string;
+  closelix?: string;
   exit_date?: string;
   assigned_account_manager?: string;
   assigned_inbox_manager?: string;
@@ -105,6 +107,7 @@ export interface ClientFilters {
   weekend_sending_mode?: string;
   assigned_account_manager_id?: string;
   assigned_inbox_manager_id?: string;
+  closelix?: string;
 }
 
 export interface ClientUpdateData {
@@ -114,6 +117,7 @@ export interface ClientUpdateData {
   avg_dollar_gen_pm?: number;
   assigned_account_manager_id?: string | null;
   assigned_inbox_manager_id?: string | null;
+  closelix?: boolean;
 }
 
 export interface BulkUpdateData {


### PR DESCRIPTION
## Summary
- show `closelix` boolean in main clients table and allow editing via dialog
- add `closelix` dropdown filter
- hide target-per-month from clients UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, require imports, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae08d4481c832e9fa14c26a7779a71