### PR TITLE
Prevent deleting team members with active client assignments

### DIFF
--- a/src/lib/teamMembersData.ts
+++ b/src/lib/teamMembersData.ts
@@ -1,3 +1,4 @@
+import { INACTIVE_STATUSES } from '@/config/statusBuckets';
 import { supabase } from '@/integrations/supabase/client';
 
 export type TeamMember = {
@@ -75,4 +76,27 @@ export async function deleteTeamMember(id: string) {
 
   // Return the pre-fetched member info (may be undefined if not found)
   return memberBefore ?? { id, full_name: '(removed)', email: '', role: 'other', active: false };
+}
+
+export async function getActiveClientAssignments(memberId: string) {
+  const { data, error } = await supabase
+    .from('clients')
+    .select('client_name')
+    .or(
+      [
+        `assigned_account_manager_id.eq.${memberId}`,
+        `assigned_inbox_manager_id.eq.${memberId}`,
+        `assigned_sdr_id.eq.${memberId}`,
+      ].join(',')
+    )
+    .is('exit_date', null)
+    .not('relationship_status', 'in', `(${INACTIVE_STATUSES.map((s) => `"${s}"`).join(',')})`);
+
+  if (error) throw error;
+
+  const names = (data ?? [])
+    .map((c) => c.client_name)
+    .filter((name): name is string => Boolean(name));
+
+  return Array.from(new Set(names));
 }

--- a/src/pages/TeamMembers.tsx
+++ b/src/pages/TeamMembers.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { listTeamMembers, createTeamMember, deleteTeamMember } from '@/lib/teamMembersData';
+import { listTeamMembers, createTeamMember, deleteTeamMember, getActiveClientAssignments } from '@/lib/teamMembersData';
 import { sendAssignmentEmail } from '@/lib/email';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -274,6 +274,25 @@ export default function TeamMembers() {
                         variant="destructive"
                         size="sm"
                         onClick={async () => {
+                          try {
+                            const assignments = await getActiveClientAssignments(member.id!);
+                            if (assignments.length > 0) {
+                              toast({
+                                variant: 'destructive',
+                                title: "Can't remove member",
+                                description: `Can't remove – ${assignments.join(', ')} are assigned. Please change assignments and try again.`,
+                              });
+                              return;
+                            }
+                          } catch (e: any) {
+                            toast({
+                              variant: 'destructive',
+                              title: 'Failed to check assignments',
+                              description: e.message || 'Unknown error',
+                            });
+                            return;
+                          }
+
                           if (!confirm(`Remove ${member.full_name}? They will be unassigned from all clients.`)) return;
                           deleteMutation.mutate(member.id!);
                         }}


### PR DESCRIPTION
## Summary
- add helper to gather active clients assigned to a team member
- block deletion with a warning when active assignments exist
- keep existing confirmation and cache removal when no assignments found

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929efe614f8832e81403304ad5047ce)